### PR TITLE
update forum and discord links for Racket and Lisp

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -190,8 +190,8 @@
       Scheme devel mailing list</a>
     </li>
     <li>
-      <a href="https://groups.google.com/g/racket-users" rel=
-      "noreferrer">Racket users mailing list (Google Groups)</a>
+      <a href="https://racket.discourse.group/" rel=
+      "noreferrer">Racket Discourse</a>
     </li>
     <li>
       <a href=
@@ -331,6 +331,10 @@
       <a href="https://get.scheme.org/racket/">Racket</a>:
       <kbd>#racket</kbd>
     </li>
+    <li>
+      <a href="https://discord.gg/6Zq8sH5" rel="noreferrer">Racket
+      Discord</a>
+    </li>
   </ul>
   <h3>Tools</h3>
   <ul>
@@ -353,6 +357,10 @@
       <kbd>#lisp</kbd> — the main channel for the Lisp family as a
       whole (<a href="https://irclog.tymoon.eu/libera/%23lisp" rel=
       "noreferrer">logs</a>)
+    </li>
+    <li>
+      <a href="https://discord.gg/hhk46CE" rel="noreferrer">Lisp
+      Discord</a>
     </li>
     <li>
       <kbd>#lispcafe</kbd> — casual, beginner-friendly channel for


### PR DESCRIPTION
1. Racket google group has been retired - community has moved to open source discourse platform  - google groups has an unmanageable spam problem
2. added lisp discord - a large discord that welcomes all members of the lisp and scheme family
3. added racket discord - where majority of Racket chat happens