### PR TITLE
add links to R5 and R6 implementations in Racket

### DIFF
--- a/get/index.html
+++ b/get/index.html
@@ -106,10 +106,11 @@
 <tr>
 <th><a href="https://racket-lang.org/">Racket</a></th>
 <td>Native code compiler</td>
-<td class="sidenote">R<sup>5</sup> R<sup>6</sup> <a 
+<td class="sidenote"><a 
+  href="https://docs.racket-lang.org/r5rs/index.html">R<sup>5</sup></a><a 
+  ref="https://docs.racket-lang.org/r6rs/index.html">R<sup>6</sup></a><a 
   title="an implementation of R7RS small" 
-  href="https://github.com/lexi-lambda/racket-r7rs">R<sup>7 
-  </sup></a></td>
+  href="https://github.com/lexi-lambda/racket-r7rs">R<sup>7</sup></a></td>
 </tr>
 <tr>
 <th><a href="https://s7.scheme.org/">s7</a></th>


### PR DESCRIPTION
add links to R5 and R6 implementations in Racket to https://get.scheme.org