### PR TITLE
add links and remove broken from implementation specific chat section

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -312,28 +312,26 @@
       rel="noreferrer">Gitter channel</a>
     </li>
     <li>
-      <a href="https://get.scheme.org/guile/">GNU Guile</a>:
+      <a href="https://guile.scheme.org/">GNU Guile</a>:
       <kbd>#guile</kbd>
     </li>
     <li>
-      <a href="https://get.scheme.org/loko/">Loko Scheme</a>:
+      <a href="https://loko.scheme.org/">Loko Scheme</a>:
       <kbd>#loko</kbd>
     </li>
-    <li>
-      <a href="https://get.scheme.org/otus/">Otus Lisp</a>:
+    <li>Otus Lisp:
       <kbd>#otus-lisp</kbd>
     </li>
-    <li>
-      <a href="https://get.scheme.org/owl/">Owl Lisp</a>:
+    <li>Owl Lisp:
       <kbd>#owl-lisp</kbd>
     </li>
     <li>
-      <a href="https://get.scheme.org/racket/">Racket</a>:
-      <kbd>#racket</kbd>
-    </li>
-    <li>
-      <a href="https://discord.gg/6Zq8sH5" rel="noreferrer">Racket
-      Discord</a>
+      <a title="Community section of racket home page has links and invites to chat services" 
+        href="https://racket-lang.org/#community">Racket</a>:
+      <a title="Racket Slack link and invite avaliable from Racket home page"
+        href="https://racket-lang.org/#community">Slack</a>
+      <a href="https://discord.gg/6Zq8sH5" rel="noreferrer">Racket Discord</a>,
+      <kbd><a href="https://kiwiirc.com/nextclient/irc.libera.chat/#racket">#racket</a>a</kbd>
     </li>
   </ul>
   <h3>Tools</h3>


### PR DESCRIPTION
1. removed broken implementation links that currently 404 
2. add links to Racket chat services as single section
3. change broken guile and loko links (e.g. https://get.scheme.org/guile/) to  guile.scheme.org and loko.scheme.org respectively 