### PR TITLE
fix unrendered images with meta http-equiv content-security-policy

### DIFF
--- a/research/lambda-papers/lambda-papers-interpreter.html
+++ b/research/lambda-papers/lambda-papers-interpreter.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta http-equiv="content-security-policy" content="img-src &#39;self&#39; data:" />
   <meta name="author" content="Guy Lewis Steele Jr (text and code)" />
   <meta name="author" content="Gerald Jay Sussman (text and code)" />
   <meta name="author" content="Roger Turner ©2025 (markup and transcriber notes)" />

--- a/research/lambda-papers/lambda-papers-ltu-goto.html
+++ b/research/lambda-papers/lambda-papers-ltu-goto.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta http-equiv="content-security-policy" content="img-src &#39;self&#39; data:" />
   <meta name="author" content="Guy Lewis Steele Jr ©1977 (text and code)" />
   <meta name="author" content="Roger Turner ©2025 (markup and transcriber notes)" />
   <meta name="keywords" content="LISP, SCHEME, procedure

--- a/research/lambda-papers/lambda-papers-ltu-imperative.html
+++ b/research/lambda-papers/lambda-papers-ltu-imperative.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta http-equiv="content-security-policy" content="img-src &#39;self&#39; data:" />
   <meta name="author" content="Guy Lewis Steele Jr ©1976 (text and code)" />
   <meta name="author" content="Gerald Jay Sussman ©1976 (text and code)" />
   <meta name="author" content="Roger Turner ©2025 (markup and transcriber notes)" />


### PR DESCRIPTION
Images are not rendered in the transcriptions on scheme.org
(example: https://research.scheme.org/lambda-papers/lambda-papers-ltu-imperative.html#flowgraph) 
(ok on github preview: https://rogerturner.github.io/monorepo/research/lambda-papers/lambda-papers-ltu-imperative.html#flowgraph)

Added `<meta http-equiv="content-security-policy" content="img-src 'self' data:" />`.
