### PR TITLE
Add r7rs-html5 under standards/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "standards/r7rs-html5"]
+	path = standards/r7rs-html5
+	url = https://codeberg.org/aartaka/r7rs-html5
+	branch = scheme-org

--- a/scripts/upload-standards.sh
+++ b/scripts/upload-standards.sh
@@ -3,3 +3,4 @@ set -eu
 cd "$(dirname "$0")"
 cd ..
 rsync -crv shared/ standards/ tuonela.scheme.org:/production/standards/www/
+git submodule update --init standards/r7rs-html5

--- a/standards/index.html
+++ b/standards/index.html
@@ -64,6 +64,10 @@
       the web):</b><br>
       <a href="corrected-r7rs/r7rs.html">R<sup>7</sup>RS Small
       Edition</a></p>
+      <p><b>Unofficial documents with errata corrected, converted to HTML5 (browse on
+      the web):</b><br>
+      <a href="r7rs-html5/index.html">R<sup>7</sup>RS Small
+      Edition</a></p>
     </div>
     <div class="round-box gray-box">
       <p><b><a href=


### PR DESCRIPTION
Hello!

This patch adds https://codeberg.org/aartaka/r7rs-html5 as an additional standard rendering. I believe that it’ll be beneficial, because the markup there is much more readable and parseable.

I’ve added it as a submodule so that it’s easier to track and update via git. I’ve also modified the `upload-standards.sh` script so that it updates the submodule automatically.

My only concern is that this submodule tracks a [scheme-org branch](https://codeberg.org/aartaka/r7rs-html5/src/branch/scheme-org) of the repository, and, in case the repository is compromised, one can push anything nasty there. I am determined to not make that happen, but, you know, no one can be trusted.