### PR TITLE
Align the version numbers in get.scheme.org list

### DIFF
--- a/get/index.html
+++ b/get/index.html
@@ -37,177 +37,247 @@
 <th><a href="https://bigloo.scheme.org/">Bigloo</a></th>
 <td>Fast Scheme-to-C and Scheme-to-JVM compiler</td>
 <td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://www.biwascheme.org/">BiwaScheme</a></th>
 <td>Scheme interpreter written in JavaScript</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://codeberg.org/playXE/capy">CapyScheme</a></th>
 <td>compiler and runtime written in Rust</td>
-<td class="sidenote">R<sup>6</sup> R<sup>7</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://chez.scheme.org/">Chez Scheme</a></th>
 <td>Cross-module optimizing native-code compiler</td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://chibi.scheme.org/">Chibi-Scheme</a></th>
 <td>Small embeddable interpreter with many optional libraries</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://chicken.scheme.org/">CHICKEN</a></th>
 <td>Scheme-to-C compiler with a big, friendly community</td>
-<td class="sidenote">R<sup>5</sup> R<sup>7</sup></td>
+<td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://cyclone.scheme.org/">Cyclone</a></th>
 <td>New Scheme-to-C compiler with native threads</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://github.com/leftmike/foment">Foment</a></th>
 <td>Foment is an implementation of Scheme</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://gambit.scheme.org/">Gambit</a></th>
 <td>Fast, concurrent, retargetable optimizing compiler</td>
-<td class="sidenote">R<sup>5</sup> R<sup>7</sup></td>
+<td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://gauche.scheme.org/">Gauche</a></th>
 <td>Fast script interpreter with many built-in libraries</td>
-<td class="sidenote">R<sup>5</sup> R<sup>7</sup></td>
+<td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://gerbil.scheme.org/">Gerbil</a></th>
 <td>Scheme with actors and objects built on Gambit</td>
-<td class="sidenote">R<sup>5</sup> R<sup>7</sup></td>
+<td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <tr>
 <th><a href="https://github.com/MoganLab/goldfish">Goldfish</a></th>
 <td>Make Scheme as easy to use and practical as Python!</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://guile.scheme.org/">Guile</a></th>
 <td>Main Scheme implementation of the GNU project</td>
-<td class="sidenote">R<sup>6</sup> R<sup>7</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://github.com/IronScheme/IronScheme">IronScheme</a></th>
 <td>Scheme-like implementation for all .NET implementations and platforms</td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://jazz.scheme.org/">JazzScheme</a></th>
 <td>Object-oriented GUI and IDE built on Gambit</td>
 <td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://kawa.scheme.org/">Kawa</a></th>
 <td>JVM compiler with many extensions to Scheme</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://lips.js.org/">LIPS</a></th>
 <td>Powerful lisp interpreter written in JavaScript</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://loko.scheme.org/">Loko</a></th>
 <td>Bare-metal native-code compiler</td>
-<td class="sidenote">R<sup>6</sup> R<sup>7</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://github.com/yamacir-kit/meevax">Meevax</a></th>
 <td>Focused on integration with modern C++ and practicality</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://mit.scheme.org/">MIT/GNU Scheme</a></th>
 <td>Native-code compiler and development environment</td>
-<td class="sidenote">R<sup>5</sup> R<sup>7</sup></td>
+<td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://mosh.scheme.org/">Mosh</a></th>
 <td>Fast and complete R<sup>6</sup>RS interpreter</td>
-<td class="sidenote">R<sup>6</sup> R<sup>7</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <tr>
 <th><a href="https://racket-lang.org/">Racket</a></th>
 <td>Native code compiler</td>
-<td class="sidenote"><a 
-  href="https://docs.racket-lang.org/r5rs/index.html">R<sup>5</sup></a> <a 
-  href="https://docs.racket-lang.org/r6rs/index.html">R<sup>6</sup></a> <a 
-  title="an implementation of R7RS small" 
-  href="https://github.com/lexi-lambda/racket-r7rs">R<sup>7</sup></a></td>
+<td class="sidenote">
+  <a href="https://docs.racket-lang.org/r5rs/index.html">R<sup>5</sup></a>
+</td>
+<td class="sidenote">
+  <a href="https://docs.racket-lang.org/r6rs/index.html">R<sup>6</sup></a>
+</td>
+<td class="sidenote">
+  <a href="https://github.com/lexi-lambda/racket-r7rs">R<sup>7</sup></a>
+</td>
 </tr>
 <tr>
 <th><a href="https://s7.scheme.org/">s7</a></th>
 <td>Embeddable interpreter for music applications</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://sagittarius.scheme.org/">Sagittarius</a></th>
 <td>Script interpreter with many built-in libraries</td>
-<td class="sidenote">R<sup>6</sup> R<sup>7</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://scheme.rs/">scheme-rs</a></th>
 <td>Embedded Scheme for the Rust Ecosystem</td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://scm.scheme.org/">SCM</a></th>
 <td>Portable C implementation that begat Guile and SLIB</td>
 <td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://github.com/uim/sigscheme">SigScheme</a></th>
 <td>Scheme interpreter for embedded use</td>
 <td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://github.com/false-schemers/skint">SKINT</a></th>
 <td>Cheap and fast R7RS Scheme Interpreter</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://raviqqe.com/stak/">Stak</a></th>
 <td>The miniature, embeddable Scheme implementation in Rust</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://github.com/mattwparas/steel">Steel</a></th>
 <td>An embedded scheme interpreter in Rust</td>
 <td class="sidenote">R<sup>5</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 </tr>
 <tr>
 <th><a href="https://stklos.scheme.org/">STklos</a></th>
 <td>Interpreter with CLOS object-oriented GUI</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://gitlab.com/jobol/tr7/">TR7</a></th>
 <td>Embeddable R<sup>7</sup>RS interpreter</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://github.com/aalpar/wile">Wile</a></th>
 <td>Embeddable bytecode compiler and VM in pure Go</td>
+<td class="sidenote"></td>
+<td class="sidenote"></td>
 <td class="sidenote">R<sup>7</sup></td>
 </tr>
 <tr>
 <th><a href="https://ypsilon.scheme.org/">Ypsilon</a></th>
 <td>Incremental native-code compiler with concurrent GC</td>
-<td class="sidenote">R<sup>6</sup> R<sup>7</sup></td>
+<td class="sidenote"></td>
+<td class="sidenote">R<sup>6</sup></td>
+<td class="sidenote">R<sup>7</sup></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
(Also removed an unnecessary description from the Racket row.)

Made the table more intuitive and structural.

Screenshot:

<img width="99" height="281" alt="get.scheme.org implementation list version numbers new" src="https://github.com/user-attachments/assets/df080e85-dd92-4d6c-acfd-959ba4427f1c" />
