### PR TITLE
Add scrollbar to <pre> blocks when overflowing

### DIFF
--- a/shared/schemeorg.css
+++ b/shared/schemeorg.css
@@ -101,6 +101,10 @@ a.offsite:visited {
   border-bottom: 1px dashed #551a8b;
 }
 
+pre {
+    overflow-x: auto;
+}
+
 .blog-posts li {
   margin-left: -2rem;
 }


### PR DESCRIPTION
This makes <pre> blocks much more readable on mobile, not needing to scroll the whole page horizontally. Particularly useful for r7rs-html5, where there are lots of wide code blocks.

Other fixes from https://aartaka.me/easy-fixes.html might be useful to apply as well.